### PR TITLE
feat: add configurable void element endings

### DIFF
--- a/jsconfig.json
+++ b/jsconfig.json
@@ -1,0 +1,9 @@
+{
+  "compilerOptions": {
+    "baseUrl": ".",
+    "paths": {
+      "@/*": ["src/*"],
+      "@@/*": ["tests/*"]
+    }
+  }
+}

--- a/src/formatMarkup.js
+++ b/src/formatMarkup.js
@@ -16,6 +16,7 @@ import { logger } from './helpers.js';
  */
 export let DIFFABLE_OPTIONS_TYPE;
 
+// From https://developer.mozilla.org/en-US/docs/Glossary/Void_element
 const VOID_ELEMENTS = Object.freeze([
   'area',
   'base',
@@ -59,28 +60,6 @@ export const diffableFormatter = function (markup, options) {
     sourceCodeLocationInfo: true
   };
   const ast = parseFragment(markup, astOptions);
-
-  // From https://developer.mozilla.org/en-US/docs/Glossary/Void_element
-  const VOID_ELEMENTS = Object.freeze([
-    'area',
-    'base',
-    'br',
-    'col',
-    'embed',
-    'hr',
-    'img',
-    'input',
-    'link',
-    'meta',
-    'param',
-    'source',
-    'track',
-    'wbr'
-  ]);
-  const WHITESPACE_DEPENDENT_TAGS = Object.freeze([
-    'a',
-    'pre'
-  ]);
 
   let lastSeenTag = '';
 

--- a/src/formatMarkup.js
+++ b/src/formatMarkup.js
@@ -39,7 +39,6 @@ const isElementNode = (node) => Object.prototype.hasOwnProperty.call(node, 'tagN
  */
 const isTextNode = (node) => node.nodeName === '#text';
 
-
 /**
  * Uses Parse5 to create an AST from the markup. Loops over the AST to create a formatted HTML string.
  *
@@ -128,7 +127,9 @@ export const formatMarkup = function (markup) {
       }
     }
     if (globalThis.vueSnapshots.formatting === 'diffable') {
-      return diffableFormatter(markup);
+      return diffableFormatter(markup, {
+        voidElements: globalThis.vueSnapshots.voidElements
+      });
     }
   }
   return markup;

--- a/src/formatMarkup.js
+++ b/src/formatMarkup.js
@@ -71,7 +71,6 @@ export const diffableFormatter = function (markup, options) {
    * @return {string}                                     Formatted markup
    */
   const formatNode = (node, indent) => {
-    node = node || {};
     indent = indent || 0;
     if (node.tagName) {
       lastSeenTag = node.tagName;
@@ -166,8 +165,6 @@ export const diffableFormatter = function (markup, options) {
         }
       });
       result = result + '\n' + '  '.repeat(indent) + endingAngleBracket.trim();
-    } else {
-      result = result + endingAngleBracket;
     }
 
     // Process child nodes

--- a/tests/unit/src/formatMarkup.test.js
+++ b/tests/unit/src/formatMarkup.test.js
@@ -1,4 +1,5 @@
 import { formatMarkup } from '@/formatMarkup.js';
+import { describe, expect, test } from 'vitest';
 
 const unformattedMarkup = `
 <div id="header">
@@ -26,7 +27,39 @@ const formattedMarkup = `
 </div>
 `.trim();
 
-describe('Formt markup', () => {
+const unformattedMarkupVoidElements = `
+<input>
+<input type="range"><input type="range" max="50">
+`.trim();
+
+const formattedMarkupVoidElementsWithHTML = `
+<input>
+<input type="range">
+<input
+  type="range"
+  max="50"
+>
+`.trim();
+
+const formattedMarkupVoidElementsWithXHTML = `
+<input />
+<input type="range" />
+<input
+  type="range"
+  max="50"
+/>
+`.trim();
+
+const formattedMarkupVoidElementsWithClosingTag = `
+<input></input>
+<input type="range"></input>
+<input
+  type="range"
+  max="50"
+></input>
+`.trim();
+
+describe('Format markup', () => {
   const info = console.info;
 
   beforeEach(() => {
@@ -82,5 +115,25 @@ describe('Formt markup', () => {
 
     expect(console.info)
       .toHaveBeenCalledWith('Vue 3 Snapshot Serializer: Your custom markup formatter must return a string.');
+  });
+});
+
+describe('Format markup options', () => {
+  beforeEach(() => {
+    globalThis.vueSnapshots = {
+      formatting: 'diffable',
+      verbose: true
+    };
+  });
+
+  test.each([
+    ['html', formattedMarkupVoidElementsWithHTML],
+    ['xhtml', formattedMarkupVoidElementsWithXHTML],
+    ['closingTag', formattedMarkupVoidElementsWithClosingTag]
+  ])('Formats void elements using mode "%s"', (mode, expected) => {
+    globalThis.vueSnapshots.voidElements = mode;
+
+    expect(formatMarkup(unformattedMarkupVoidElements))
+      .toEqual(expected);
   });
 });

--- a/tests/unit/src/formatMarkup.test.js
+++ b/tests/unit/src/formatMarkup.test.js
@@ -251,7 +251,7 @@ describe('Format markup', () => {
 
   describe('Void elements', () => {
     beforeEach(() => {
-      globalThis.vueSnapshots.formatting = 'diffable';
+      globalThis.vueSnapshots.formatter = 'diffable';
     });
 
     const voidElementTests = [

--- a/tests/unit/src/formatMarkup.test.js
+++ b/tests/unit/src/formatMarkup.test.js
@@ -261,7 +261,7 @@ describe('Format markup', () => {
     ];
 
     test.each(voidElementTests)('Formats void elements using mode "%s"', (mode, expected) => {
-      globalThis.vueSnapshots.voidElements = mode;
+      globalThis.vueSnapshots.formatting.voidElements = mode;
 
       expect(formatMarkup(unformattedMarkupVoidElements))
         .toEqual(expected);


### PR DESCRIPTION
<!-- Replace 0 with the issue this PR relates to -->
Related to issue #8

### Notes for reviewer

* this is a pretty quick/dirty solution, open to any feedback
* tests are passing, with 97.63% coverage
* tests need to be added for the new functionality, should it be tested independently from the existing `unformattedMarkup` and `formattedMarkup` in`tests/unit/src/formatMarkup.test.js`?

<!-- If you don't know what this is, ignore it -->
### Checklist

* [ ] Update dependencies
* [ ] Bump
