### PR TITLE
Bugfix: Missing Final Returns

### DIFF
--- a/src/formatMarkup.js
+++ b/src/formatMarkup.js
@@ -52,9 +52,9 @@ const ESCAPABLE_RAW_TEXT_ELEMENTS = Object.freeze([
 ]);
 
 /**
- * Returns the last child node of an AST node if it exists or returns null
+ * Returns the last child node of an AST node if it exists or returns null.
  *
- * @param  {DefaultTreeAdapterMap["element"]}  node  Current AST DOM Node
+ * @param  {DefaultTreeAdapterMap["element"]}   node  Current AST DOM Node
  * @return {DefaultTreeAdapterMap["childNode"]}       Last child node or null
  */
 const getNonTextChildNode = (node) => {

--- a/src/formatMarkup.js
+++ b/src/formatMarkup.js
@@ -63,7 +63,7 @@ const getNonTextChildNode = (node) => {
     const isTextNode = defaultTreeAdapter.isTextNode(childNode);
     const isEmptyString = isTextNode && childNode.value.trim() === '';
     
-    if(!isEmptyString) {
+    if (!isEmptyString) {
       return node.childNodes[i];
     }
   }

--- a/tests/unit/src/formatMarkup.test.js
+++ b/tests/unit/src/formatMarkup.test.js
@@ -601,7 +601,7 @@ describe('Format markup', () => {
     });
   });
 
-  describe.only('Complex', () => {
+  describe('Complex', () => {
     let MyComponent = {
       template: `
       <div id="header" data-server-rendered>

--- a/tests/unit/src/formatMarkup.test.js
+++ b/tests/unit/src/formatMarkup.test.js
@@ -600,4 +600,56 @@ describe('Format markup', () => {
         `);
     });
   });
+
+  describe.only('Complex', () => {
+    let MyComponent = {
+      template: `
+      <div id="header" data-server-rendered>
+        <!--v-if-->
+        <label data-test="input" data-v-1ae75a9f="">
+          Void and Attributes per line Example:
+          <input />
+          <input type="range" />
+          <input type="range" max="50" />
+          <input type="range" max="50" id="slider" >
+        </label>
+        <p class="">Empty attribute example</p>
+        <div></div>
+        <ul><li><a href="#">Link text on same line</a></li></ul>
+      </div>`
+    };
+    test('Two Complex', async () => {
+      const wrapper = mount(MyComponent);
+      // const markup = wrapper.html();
+      globalThis.vueSnapshots.formatter = 'diffable';
+      globalThis.vueSnapshots.formatting.tagsWithWhitespacePreserved = true;
+
+      expect(wrapper).toMatchInlineSnapshot(`
+        <div id="header">
+          <!-- v-if -->
+          <label> Void and Attributes per line Example: 
+            <input value="''" />
+            <input
+              type="range"
+              value="''"
+            />
+            <input
+              max="50"
+              type="range"
+              value="''"
+            />
+            <input
+              id="slider"
+              max="50"
+              type="range"
+              value="''"
+            />
+          </label>
+          <p class="">Empty attribute example</p>
+          <div></div>
+          <ul><li><a href="#">Link text on same line</a></li></ul>
+        </div>
+      `);
+    });
+  });
 });


### PR DESCRIPTION
Moved code into respective functions
Added code to check if tag is in same line as child and append closing tag based on it

<!-- Replace 0 with the issue this PR relates to -->
Related to issue #39 


**Notes for reviewer:**

* Extracted logic related to comments and attributes into separate functions for better modularity and readability.
* Added logic to verify if a return should be present before an end tag. The implementation is as follows:
* If a node is an end tag, check if it has children, if so, then fetch the last child.
> return lastchild.sourceLocation.endline === node.endtag.endline;

If no children, then check it’s own start tag endline, 

> return node.starttag.endline == node.endtag.endline.

* For the specific test case used below, the AST shows that the last input tag's startLine and endLine values are 2, which matches the label tag.
* This behavior occurs even though the two tags are on separate lines.
* I also tried importing the test case from a .vue file, but the source code locations remained the same.

* @TheJaredWilcurt, Could you please review this behavior? 
* Let me know if I am overlooking anything or if there's an issue with the AST interpretation. 

<!-- If you don't know what this is, ignore it -->
**Checklist:**

* [ ] Update dependencies
* [ ] Bump
