### PR TITLE
Don't error for null values

### DIFF
--- a/src/helpers.js
+++ b/src/helpers.js
@@ -25,6 +25,7 @@ export const isHtmlString = function (received) {
 export const isVueWrapper = function (received) {
   return (
     typeof(received) === 'object' &&
+    received !== null &&
     typeof(received.html) === 'function'
   );
 };

--- a/tests/unit/index.test.js
+++ b/tests/unit/index.test.js
@@ -21,6 +21,11 @@ describe('index.js', () => {
         .toEqual(false);
     });
 
+    test('Null is invalid', () => {
+      expect(vue3SnapshotSerializer.test(null))
+        .toEqual(false);
+    });
+
     test('Object resembling Vue wrapper is valid', () => {
       expect(vue3SnapshotSerializer.test({ html: vi.fn() }))
         .toEqual(true);


### PR DESCRIPTION
Without this change, the serializer errored when passed `null`,:

```
Cannot read properties of null (reading 'html')
```

This is because `typeof null === 'object'` (see [MDN](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Operators/typeof#typeof_null), so this PR adds an explicit check for `null` and a test for that.

**Checklist:**

* [ ] Update dependencies
* [ ] Bump
