### PR TITLE
Add named exports for `test` and `print`

### DIFF
--- a/index.js
+++ b/index.js
@@ -15,7 +15,7 @@ import { formatMarkup } from './src/formatMarkup.js';
  * @param  {string|object} received  The markup or Vue wrapper to be formatted
  * @return {boolean}                 true = Tells Vitest to run the print function
  */
-const test = function (received) {
+export const test = function (received) {
   return isHtmlString(received) || isVueWrapper(received);
 };
 
@@ -26,7 +26,7 @@ const test = function (received) {
  * @param  {string|object} received  The markup or Vue wrapper to be formatted
  * @return {string}                  The formatted markup
  */
-const print = function (received) {
+export const print = function (received) {
   loadOptions();
   let html = received || '';
   html = stringManipulation(html);


### PR DESCRIPTION
I tried to use vue3-snapshot-serializer with Jest in a CommonJS project. Since this package is ESM-only, I added `transformIgnorePatterns: ['/node_modules/(?!vue3-snapshot-serializer)']` to my `jest.config.js`. `.js` files are configured to be transpiled to CommonJS via `babel-jest`.

This yields an error: `TypeError: plugins[p].test is not a function`. This is because the transpiled output looks like the following:

```js
module.exports = {
  vueMarkupFormatter,
  default: { test, print }
}
```

Adding named exports for the `test` and `print` functions solves this problem, because the transpiled output then looks like this:

```js
module.exports = {
  test,
  print,
  vueMarkupFormatter,
  default: { test, print }
}
```