### PR TITLE
Post processing

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,3 +12,4 @@ Related to issue #0
 
 * [ ] Update dependencies
 * [ ] Bump
+* [ ] If API changed, update `types.js`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue3-snapshot-serializer",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vue3-snapshot-serializer",
-      "version": "1.0.1",
+      "version": "2.0.0",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0",
@@ -14,12 +14,12 @@
         "parse5": "^7.2.1"
       },
       "devDependencies": {
-        "@eslint/js": "^9.16.0",
+        "@eslint/js": "^9.17.0",
         "@stylistic/eslint-plugin-js": "^2.12.1",
         "@vitejs/plugin-vue": "^5.2.1",
         "@vitest/coverage-v8": "^2.1.8",
         "@vue/test-utils": "^2.4.6",
-        "eslint": "^9.16.0",
+        "eslint": "^9.17.0",
         "eslint-config-tjw-base": "^3.1.0",
         "eslint-config-tjw-jsdoc": "^2.0.1",
         "eslint-plugin-jsdoc": "^50.6.1",
@@ -593,9 +593,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.16.0.tgz",
-      "integrity": "sha512-tw2HxzQkrbeuvyj1tG2Yqq+0H9wGoI2IMk4EOsQeX+vmd75FtJAzf+gTA69WF+baUKRYQ3x2kbLE08js5OsTVg==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.17.0.tgz",
+      "integrity": "sha512-Sxc4hqcs1kTu0iID3kcZDW3JHq2a77HO9P8CP6YEA/FpH3Ll8UXE2r/86Rz9YJLKme39S9vU5OWNjC6Xl0Cr3w==",
       "dev": true,
       "license": "MIT",
       "engines": {
@@ -1665,10 +1665,11 @@
       }
     },
     "node_modules/cross-spawn": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.5.tgz",
-      "integrity": "sha512-ZVJrKKYunU38/76t0RMOulHOnUcbU9GbpWKAOZ0mhjr7CX6FVrH+4FrAapSOekrgFQ3f/8gwMEuIft0aKq6Hug==",
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
       "dev": true,
+      "license": "MIT",
       "dependencies": {
         "path-key": "^3.1.0",
         "shebang-command": "^2.0.0",
@@ -1948,9 +1949,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.16.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.16.0.tgz",
-      "integrity": "sha512-whp8mSQI4C8VXd+fLgSM0lh3UlmcFtVwUQjyKCFfsp+2ItAIYhlq/hqGahGqHE6cv9unM41VlqKk2VtKYR2TaA==",
+      "version": "9.17.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.17.0.tgz",
+      "integrity": "sha512-evtlNcpJg+cZLcnVKwsai8fExnqjGPicK7gnUtlNuzu+Fv9bI0aLpND5T44VLQtoMEnI57LoXO9XAkIXwohKrA==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -1959,7 +1960,7 @@
         "@eslint/config-array": "^0.19.0",
         "@eslint/core": "^0.9.0",
         "@eslint/eslintrc": "^3.2.0",
-        "@eslint/js": "9.16.0",
+        "@eslint/js": "9.17.0",
         "@eslint/plugin-kit": "^0.2.3",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",
@@ -1968,7 +1969,7 @@
         "@types/json-schema": "^7.0.15",
         "ajv": "^6.12.4",
         "chalk": "^4.0.0",
-        "cross-spawn": "^7.0.5",
+        "cross-spawn": "^7.0.6",
         "debug": "^4.3.2",
         "escape-string-regexp": "^4.0.0",
         "eslint-scope": "^8.2.0",

--- a/package.json
+++ b/package.json
@@ -1,13 +1,14 @@
 {
   "name": "vue3-snapshot-serializer",
   "type": "module",
-  "version": "1.0.1",
+  "version": "2.0.0",
   "description": "Vitest snapshot serializer for Vue 3 components",
   "main": "index.js",
   "scripts": {
     "lint": "eslint *.js src tests",
     "fix": "npm run lint -- --fix",
     "test": "vitest --coverage",
+    "unit": "vitest --run",
     "debug": "vitest --inspect-brk --no-file-parallelism -t \"Stringify attributes\" \"cheerio\""
   },
   "dependencies": {
@@ -16,12 +17,12 @@
     "parse5": "^7.2.1"
   },
   "devDependencies": {
-    "@eslint/js": "^9.16.0",
+    "@eslint/js": "^9.17.0",
     "@stylistic/eslint-plugin-js": "^2.12.1",
     "@vitejs/plugin-vue": "^5.2.1",
     "@vitest/coverage-v8": "^2.1.8",
     "@vue/test-utils": "^2.4.6",
-    "eslint": "^9.16.0",
+    "eslint": "^9.17.0",
     "eslint-config-tjw-base": "^3.1.0",
     "eslint-config-tjw-jsdoc": "^2.0.1",
     "eslint-plugin-jsdoc": "^50.6.1",

--- a/src/formatMarkup.js
+++ b/src/formatMarkup.js
@@ -296,7 +296,7 @@ export const formatMarkup = function (markup) {
     if (typeof(globalThis.vueSnapshots.postProcessor) === 'function') {
       markup = globalThis.vueSnapshots.postProcessor(markup);
       if (typeof(markup) !== 'string') {
-        logger('Your custom markup formatter must return a string.');
+        logger('Your custom markup post processor must return a string.');
         return '';
       }
     }

--- a/src/formatMarkup.js
+++ b/src/formatMarkup.js
@@ -289,16 +289,16 @@ export const diffableFormatter = function (markup) {
  * @return {string}         The same string, formatted based on user settings.
  */
 export const formatMarkup = function (markup) {
-  if (globalThis.vueSnapshots?.formatter) {
-    if (typeof(globalThis.vueSnapshots.formatter) === 'function') {
-      const result = globalThis.vueSnapshots.formatter(markup);
-      if (typeof(result) === 'string') {
-        return result;
-      } else {
+  if (globalThis.vueSnapshots) {
+    if (globalThis.vueSnapshots.formatter === 'diffable') {
+      markup = diffableFormatter(markup);
+    }
+    if (typeof(globalThis.vueSnapshots.postProcessor) === 'function') {
+      markup = globalThis.vueSnapshots.postProcessor(markup);
+      if (typeof(markup) !== 'string') {
         logger('Your custom markup formatter must return a string.');
+        return '';
       }
-    } else if (globalThis.vueSnapshots.formatter === 'diffable') {
-      return diffableFormatter(markup, globalThis.vueSnapshots.formatting);
     }
   }
   return markup;

--- a/src/loadOptions.js
+++ b/src/loadOptions.js
@@ -85,12 +85,9 @@ export const loadOptions = function () {
   globalThis.vueSnapshots.attributesToClear = attributesToClear;
 
   // Formatter
-  if (
-    typeof(globalThis.vueSnapshots.formatter) !== 'function' &&
-    !['none', 'diffable'].includes(globalThis.vueSnapshots.formatter)
-  ) {
+  if (!['none', 'diffable'].includes(globalThis.vueSnapshots.formatter)) {
     if (globalThis.vueSnapshots.formatter) {
-      logger('Allowed values for global.vueSnapshots.formatter are \'none\', \'diffable\', or a custom function');
+      logger('Allowed values for global.vueSnapshots.formatter are \'none\' and \'diffable\'.');
     }
     globalThis.vueSnapshots.formatter = undefined;
   }
@@ -103,7 +100,7 @@ export const loadOptions = function () {
     typeof(globalThis.vueSnapshots.formatting) === 'object' &&
     Object.keys(globalThis.vueSnapshots.formatting).length
   ) {
-    logger('When setting the formatter to "none" or a custom function, all formatting options will be removed.');
+    logger('When setting the formatter to anything other than \'diffable\', all formatting options are ignored.');
   }
 
   // Formatting
@@ -177,6 +174,13 @@ export const loadOptions = function () {
     delete globalThis.vueSnapshots.formatting;
   }
 
+  if (typeof(globalThis.vueSnapshots.postProcessor) !== 'function') {
+    if (globalThis.vueSnapshots.postProcessor) {
+      logger('The postProcessor option must be a function that returns a string, or undefined.');
+    }
+    delete globalThis.vueSnapshots.postProcessor;
+  }
+
   /**
    * Clean up settings
    */
@@ -185,7 +189,8 @@ export const loadOptions = function () {
     ...Object.keys(booleanDefaults),
     'attributesToClear',
     'formatter',
-    'formatting'
+    'formatting',
+    'postProcessor'
   ];
   const permittedFormattingKeys = [
     ...Object.keys(formattingBooleanDefaults),

--- a/tests/unit/src/formatMarkup.test.js
+++ b/tests/unit/src/formatMarkup.test.js
@@ -101,7 +101,7 @@ describe('Format markup', () => {
       .toMatchInlineSnapshot('');
 
     expect(console.info)
-      .toHaveBeenCalledWith('Vue 3 Snapshot Serializer: Your custom markup formatter must return a string.');
+      .toHaveBeenCalledWith('Vue 3 Snapshot Serializer: Your custom markup post processor must return a string.');
   });
 
   describe('diffableFormatter', () => {

--- a/tests/unit/src/formatMarkup.test.js
+++ b/tests/unit/src/formatMarkup.test.js
@@ -64,29 +64,41 @@ describe('Format markup', () => {
   });
 
   test('Applies custom formatting', () => {
-    globalThis.vueSnapshots.formatter = function () {
-      return 'test';
+    globalThis.vueSnapshots.postProcessor = function (input) {
+      return input.toUpperCase();
     };
 
-    expect(formatMarkup(unformattedMarkup))
-      .toEqual('test');
+    expect(unformattedMarkup)
+      .toMatchInlineSnapshot(`
+        <DIV ID="HEADER">
+          <H1>
+            HELLO WORLD!
+          </H1>
+          <UL
+            CLASS="LIST"
+            ID="MAIN-LIST"
+          >
+            <LI>
+              <A
+                CLASS="LINK"
+                HREF="#"
+              >MY HTML</A>
+            </LI>
+          </UL>
+        </DIV>
+      `);
 
     expect(console.info)
       .not.toHaveBeenCalled();
   });
 
   test('Logs warning if custom function does not return a string', () => {
-    globalThis.vueSnapshots.formatter = function () {
+    globalThis.vueSnapshots.postProcessor = function () {
       return 5;
     };
 
     expect(unformattedMarkup)
-      .toMatchInlineSnapshot(`
-        <div id="header">
-          <h1>Hello World!</h1>
-          <ul class="list" id="main-list"><li><a class="link" href="#">My HTML</a></li></ul>
-        </div>
-      `);
+      .toMatchInlineSnapshot('');
 
     expect(console.info)
       .toHaveBeenCalledWith('Vue 3 Snapshot Serializer: Your custom markup formatter must return a string.');

--- a/tests/unit/src/loadOptions.test.js
+++ b/tests/unit/src/loadOptions.test.js
@@ -140,7 +140,7 @@ describe('Load options', () => {
         .toEqual('diffable');
 
       expect(console.info)
-        .toHaveBeenCalledWith('Vue 3 Snapshot Serializer: Allowed values for global.vueSnapshots.formatter are \'none\', \'diffable\', or a custom function');
+        .toHaveBeenCalledWith('Vue 3 Snapshot Serializer: Allowed values for global.vueSnapshots.formatter are \'none\' and \'diffable\'.');
     });
 
     test('None', () => {
@@ -169,21 +169,6 @@ describe('Load options', () => {
         .not.toHaveBeenCalled();
     });
 
-    test('Custom function', () => {
-      function formatter (markup) {
-        return markup.toUpperCase();
-      }
-      global.vueSnapshots = { formatter };
-
-      loadOptions();
-
-      expect(globalThis.vueSnapshots.formatter)
-        .toEqual(formatter);
-
-      expect(console.info)
-        .not.toHaveBeenCalled();
-    });
-
     test('Warns and deletes formatting options if not using diffable formatter', () => {
       global.vueSnapshots.formatter = 'none';
       global.vueSnapshots.formatting = { emptyAttributes: true };
@@ -194,7 +179,38 @@ describe('Load options', () => {
         .toEqual(undefined);
 
       expect(console.info)
-        .toHaveBeenCalledWith('Vue 3 Snapshot Serializer: When setting the formatter to "none" or a custom function, all formatting options will be removed.');
+        .toHaveBeenCalledWith('Vue 3 Snapshot Serializer: When setting the formatter to anything other than \'diffable\', all formatting options are ignored.');
+    });
+  });
+
+  describe('Post processing markup', () => {
+    test('Warns if postProcessor is not a function', () => {
+      global.vueSnapshots = {
+        postProcessor: 'invalid'
+      };
+
+      loadOptions();
+
+      expect(globalThis.vueSnapshots.postProcessor)
+        .toEqual(undefined);
+
+      expect(console.info)
+        .toHaveBeenCalledWith('Vue 3 Snapshot Serializer: The postProcessor option must be a function that returns a string, or undefined.');
+    });
+
+    test('Applies custom formatting after Diffable', () => {
+      function postProcessor (markup) {
+        return markup.toUpperCase();
+      }
+      global.vueSnapshots = { postProcessor };
+
+      loadOptions();
+
+      expect(globalThis.vueSnapshots.postProcessor)
+        .toEqual(postProcessor);
+
+      expect(console.info)
+        .not.toHaveBeenCalled();
     });
   });
 

--- a/types.js
+++ b/types.js
@@ -3,15 +3,15 @@
  */
 
 /**
- * Optional custom function to format the output of the markup prior to being used in the snapshot.
- * Must return a string (not a promise).
+ * Optional custom function to apply any adjustments to the markup prior to being used in the snapshot.
+ * Must return a string (not a promise). Is ran after the formatter.
  *
- * @typedef {Function} FORMATTERCB
- * @param   {string}   markup       A string of HTML markup to format.
- * @return  {string}                Your formatted string to use as the snapshot.
+ * @typedef {Function} POSTPROCESSOR
+ * @param   {string}   markup         A string of formatted HTML markup.
+ * @return  {string}                  Mutated version of the markup string to store in a snapshot.
  */
 
-/** @typedef {'none'|'diffable'|FORMATTERCB} FORMATTER */
+/** @typedef {'none'|'diffable'} FORMATTER */
 
 /** @typedef {'html'|'xhtml'|'xml'} VOIDELEMENTS */
 
@@ -26,26 +26,27 @@
  */
 
 /**
- * @typedef  {object}     SETTINGS
- * @property {boolean}    [verbose=true]                Logs to the console errors or other messages if true.
- * @property {string[]}   [attributesToClear=[]]        Takes an array of attribute strings, like `['title', 'id']`, to remove the values from these attributes. `<i title="9:04:55 AM" id="uuid_48a50d2" class="current-time"></i>` becomes `<i title id class="current-time"></i>`.
- * @property {boolean}    [addInputValues=true]         Display current internal element value on `input`, `textarea`, and `select` fields. `<input>` becomes `<input value="'whatever'">`. Requires passing in the VTU `wrapper`, not `wrapper.html()`.
- * @property {boolean}    [sortAttributes=true]         Sorts the attributes inside HTML elements in the snapshot. This greatly reduces snapshot noise, making diffs easier to read.
- * @property {boolean}    [stringifyAttributes=true]    Injects the real values of dynamic attributes/props into the snapshot. `to="[object Object]"` becomes `to="{ name: 'home' }"`. Requires passing in the VTU `wrapper`, not `wrapper.html()`.
- * @property {boolean}    [removeServerRendered=true]   Removes `data-server-rendered="true"` from your snapshots if true.
- * @property {boolean}    [removeDataVId=true]          Removes `data-v-1234abcd=""` from your snapshots if true. Useful if 3rd-party components use scoped styles to reduce snapshot noise when updating dependencies.
- * @property {boolean}    [removeDataTest=true]         Removes `data-test="whatever"` from your snapshots if true.
- * @property {boolean}    [removeDataTestid=true]       Removes `data-testid="whatever"` from your snapshots if true.
- * @property {boolean}    [removeDataTestId=true]       Removes `data-test-id="whatever"` from your snapshots if true.
- * @property {boolean}    [removeDataQa=false]          Removes `data-qa="whatever"` from your snapshots if true. `data-qa` is usually used by non-dev QA members. If they change in your snapshot, that indicates it may break someone else's E2E tests. So most using `data-qa` prefer they be left in by default.
- * @property {boolean}    [removeDataCy=false]          Removes `data-cy="whatever"` from your snapshots if true. `data-cy` is used by Cypress end-to-end tests. If they change in your snapshot, that indicates it may break an E2E test. So most using data-cy prefer they be left in by default.
- * @property {boolean}    [removeDataPw=false]          Removes `data-pw="whatever"` from your snapshots if true. `data-pw` is used by Playwright end-to-end tests. If they change in your snapshot, that indicates it may break an E2E test. So most using data-pw prefer they be left in by default.
- * @property {boolean}    [removeIdTest=false]          Removes `id="test-whatever"` or `id="testWhatever"` from snapshots. **Warning:** You should never use ID's for test tokens, as they can also be used by JS and CSS, making them more brittle and their intent less clear. Use `data-test-id` instead.
- * @property {boolean}    [removeClassTest=false]       Removes all CSS classes that start with "test", like `class="test-whatever"`. **Warning:** Don't use this approach. Use `data-test` instead. It is better suited for this because it doesn't conflate CSS and test tokens.
- * @property {boolean}    [removeComments=false]        Removes all HTML comments from your snapshots. This is false by default, as sometimes these comments can infer important information about how your DOM was rendered. However, this is mostly just personal preference.
- * @property {boolean}    [clearInlineFunctions=false]  Replaces `<div title="function () { return true; }"></div>` or `<div title="(x) => !x"></div>` with this placeholder `<div title="[function]"></div>`.
- * @property {FORMATTER}  [formatter='diffable']        Function to use for formatting the markup output. Accepts 'none', 'diffable', or a function. If using a custom function it will be handed a string of markup and must return a string (not a promise).
- * @property {FORMATTING} [formatting]                  An object containing settings specific to the "diffable" formatter.
+ * @typedef  {object}        SETTINGS
+ * @property {boolean}       [verbose=true]                Logs to the console errors or other messages if true.
+ * @property {string[]}      [attributesToClear=[]]        Takes an array of attribute strings, like `['title', 'id']`, to remove the values from these attributes. `<i title="9:04:55 AM" id="uuid_48a50d2" class="current-time"></i>` becomes `<i title id class="current-time"></i>`.
+ * @property {boolean}       [addInputValues=true]         Display current internal element value on `input`, `textarea`, and `select` fields. `<input>` becomes `<input value="'whatever'">`. Requires passing in the VTU `wrapper`, not `wrapper.html()`.
+ * @property {boolean}       [sortAttributes=true]         Sorts the attributes inside HTML elements in the snapshot. This greatly reduces snapshot noise, making diffs easier to read.
+ * @property {boolean}       [stringifyAttributes=true]    Injects the real values of dynamic attributes/props into the snapshot. `to="[object Object]"` becomes `to="{ name: 'home' }"`. Requires passing in the VTU `wrapper`, not `wrapper.html()`.
+ * @property {boolean}       [removeServerRendered=true]   Removes `data-server-rendered="true"` from your snapshots if true.
+ * @property {boolean}       [removeDataVId=true]          Removes `data-v-1234abcd=""` from your snapshots if true. Useful if 3rd-party components use scoped styles to reduce snapshot noise when updating dependencies.
+ * @property {boolean}       [removeDataTest=true]         Removes `data-test="whatever"` from your snapshots if true.
+ * @property {boolean}       [removeDataTestid=true]       Removes `data-testid="whatever"` from your snapshots if true.
+ * @property {boolean}       [removeDataTestId=true]       Removes `data-test-id="whatever"` from your snapshots if true.
+ * @property {boolean}       [removeDataQa=false]          Removes `data-qa="whatever"` from your snapshots if true. `data-qa` is usually used by non-dev QA members. If they change in your snapshot, that indicates it may break someone else's E2E tests. So most using `data-qa` prefer they be left in by default.
+ * @property {boolean}       [removeDataCy=false]          Removes `data-cy="whatever"` from your snapshots if true. `data-cy` is used by Cypress end-to-end tests. If they change in your snapshot, that indicates it may break an E2E test. So most using data-cy prefer they be left in by default.
+ * @property {boolean}       [removeDataPw=false]          Removes `data-pw="whatever"` from your snapshots if true. `data-pw` is used by Playwright end-to-end tests. If they change in your snapshot, that indicates it may break an E2E test. So most using data-pw prefer they be left in by default.
+ * @property {boolean}       [removeIdTest=false]          Removes `id="test-whatever"` or `id="testWhatever"` from snapshots. **Warning:** You should never use ID's for test tokens, as they can also be used by JS and CSS, making them more brittle and their intent less clear. Use `data-test-id` instead.
+ * @property {boolean}       [removeClassTest=false]       Removes all CSS classes that start with "test", like `class="test-whatever"`. **Warning:** Don't use this approach. Use `data-test` instead. It is better suited for this because it doesn't conflate CSS and test tokens.
+ * @property {boolean}       [removeComments=false]        Removes all HTML comments from your snapshots. This is false by default, as sometimes these comments can infer important information about how your DOM was rendered. However, this is mostly just personal preference.
+ * @property {boolean}       [clearInlineFunctions=false]  Replaces `<div title="function () { return true; }"></div>` or `<div title="(x) => !x"></div>` with this placeholder `<div title="[function]"></div>`.
+ * @property {POSTPROCESSOR} [postProcessor]               This is a custom function you can pass in. It will be handed a string of formatted markup and must return a string (not a promise). It runs right after the formatter.
+ * @property {FORMATTER}     [formatter='diffable']        Function to use for formatting the markup output. Accepts 'none', 'diffable', or a function. If using a custom function it will be handed a string of markup and must return a string (not a promise).
+ * @property {FORMATTING}    [formatting]                  An object containing settings specific to the "diffable" formatter.
  */
 
 export const types = {};


### PR DESCRIPTION
This separates the custom markup function from the formatter setting.

**Reasoning:**

* You should be able to easily mutate snapshots without having to work around this library.
* You should be able to do global mutations (like applying the same regex replacements), or one-off tweaks for a specific test.
* You should not have to pick between using the diffable formatter, or being able to make tweaks.

**Checklist:**

* [x] Update dependencies
* [x] Bump
