### PR TITLE
attributesNotToStringify

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -11,7 +11,7 @@ Related to issue #0
 **Checklist:**
 
 * [ ] Update documentation site
-* [ ] Update dependencies
-* [ ] Run `volta pin node@latest && volta pin npm@latest` 
-* [ ] Bump
+* [ ] Update dependencies - `npm outdated`
+* [ ] `npm run volta`
+* [ ] `npm run bump`
 * [ ] If API changed, update `types.js`

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vue3-snapshot-serializer",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vue3-snapshot-serializer",
-      "version": "2.8.0",
+      "version": "2.9.0",
       "license": "MIT",
       "dependencies": {
         "cheerio": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vue3-snapshot-serializer",
   "type": "module",
-  "version": "2.8.0",
+  "version": "2.9.0",
   "description": "Vitest snapshot serializer for Vue 3 components",
   "main": "index.js",
   "scripts": {
@@ -9,6 +9,8 @@
     "fix": "npm run lint -- --fix",
     "test": "vitest --coverage",
     "unit": "vitest --run",
+    "volta": "volta pin node@latest && volta pin npm@latest",
+    "bump": "npx --yes -- @jsdevtools/version-bump-prompt && npm i",
     "debug": "vitest --inspect-brk --no-file-parallelism -t \"Renders\" \"testingLibrary\""
   },
   "dependencies": {

--- a/src/cheerioManipulation.js
+++ b/src/cheerioManipulation.js
@@ -226,7 +226,11 @@ const stringifyAttributes = function ($, vueWrapper) {
           const attributeNames = Object.keys(attributes);
           for (let attributeName of attributeNames) {
             let value = vnode?.wrapperElement?.__vnode?.props?.[attributeName];
-            if (value !== undefined && typeof(value) !== 'string') {
+            if (
+              value !== undefined &&
+              typeof(value) !== 'string' &&
+              !globalThis.vueSnapshots.attributesNotToStringify.includes(attributeName)
+            ) {
               value = swapQuotes(stringify(value));
               $(element).attr(attributeName, value);
             }
@@ -236,14 +240,14 @@ const stringifyAttributes = function ($, vueWrapper) {
           const attributes = Array.from(vnode.attributes);
           for (let attribute of attributes) {
             const attributeName = attribute.name;
-            let value;
-            if (vnode.__vnode?.props?.[attributeName] !== undefined) {
-              value = vnode.__vnode.props[attributeName];
-            } else {
-              value = attribute.value;
-            }
-            if (value !== undefined && typeof(value) !== 'string') {
-              value = swapQuotes(stringify(value));
+            let value = attribute.value;
+            if (!globalThis.vueSnapshots.attributesNotToStringify.includes(attributeName)) {
+              if (vnode.__vnode?.props?.[attributeName] !== undefined) {
+                value = vnode.__vnode.props[attributeName];
+              }
+              if (value !== undefined && typeof(value) !== 'string') {
+                value = swapQuotes(stringify(value));
+              }
             }
             $(element).attr(attributeName, value);
           }

--- a/src/loadOptions.js
+++ b/src/loadOptions.js
@@ -40,6 +40,7 @@ const ALLOWED_FORMATTERS = [
   'diffable',
   'none'
 ];
+const ATTRIBUTES_NOT_TO_STRINGIFY_DEFAULTS = ['style'];
 const TAGS_WITH_WHITESPACE_PRESERVED_DEFAULTS = ['a', 'pre'];
 const VOID_ELEMENTS_DEFAULT = 'xhtml';
 const ALLOWED_VOID_ELEMENTS = Object.freeze([
@@ -109,6 +110,25 @@ export const loadOptions = function () {
     }
   }
   globalThis.vueSnapshots.attributesToClear = attributesToClear;
+
+  let attributesNotToStringify = [];
+  if (Array.isArray(globalThis.vueSnapshots.attributesNotToStringify)) {
+    for (const attribute of globalThis.vueSnapshots.attributesNotToStringify) {
+      if (
+        typeof(attribute) === 'string' &&
+        !attribute.trim().includes(' ')
+      ) {
+        attributesNotToStringify.push(attribute.trim());
+      } else if (typeof(attribute) === 'string' && attribute.includes(' ')) {
+        logger('Attributes should not inlcude a space in global.vueSnapshots.attributesNotToStringify. Received: ' + attribute);
+      } else {
+        logger('Attributes must be a type of string in global.vueSnapshots.attributesNotToStringify. Received: ' + attribute);
+      }
+    }
+  } else {
+    attributesNotToStringify = ATTRIBUTES_NOT_TO_STRINGIFY_DEFAULTS;
+  }
+  globalThis.vueSnapshots.attributesNotToStringify = attributesNotToStringify;
 
   // Normalize Stubs
   const stubs = globalThis.vueSnapshots.stubs;
@@ -366,6 +386,7 @@ export const loadOptions = function () {
 
   const permittedRootKeys = [
     ...Object.keys(booleanDefaults),
+    'attributesNotToStringify',
     'attributesToClear',
     'classicFormatting',
     'formatter',

--- a/tests/mockComponents/AttributesNotToStringify.vue
+++ b/tests/mockComponents/AttributesNotToStringify.vue
@@ -1,0 +1,15 @@
+<template>
+  <h1
+    :class="{ active: true, disabled: false }"
+    :style="{ background: '#F00', width: 0 }"
+    :title="{ a: 2 }"
+  >
+    Text
+  </h1>
+</template>
+
+<script>
+export default {
+  name: 'AttributesNotToStringify'
+};
+</script>

--- a/tests/unit/src/cheerioManipulation.test.js
+++ b/tests/unit/src/cheerioManipulation.test.js
@@ -4,6 +4,7 @@ import { mount } from '@vue/test-utils';
 
 import { cheerioManipulation } from '@/cheerioManipulation.js';
 
+import AttributesNotToStringify from '@@/mockComponents/AttributesNotToStringify.vue';
 import DataVId from '@@/mockComponents/DataVId.vue';
 import CheckboxesAndRadios from '@@/mockComponents/CheckboxesAndRadios.vue';
 import EmbeddedStyles from '@@/mockComponents/EmbeddedStyles.vue';
@@ -403,6 +404,80 @@ describe('Cheerio Manipulation', () => {
 
       expect(wrapper)
         .toMatchSnapshot();
+    });
+  });
+
+  describe('Attributes not to stringify', () => {
+    test('Skips style by default', async () => {
+      globalThis.vueSnapshots.stringifyAttributes = true;
+      globalThis.vueSnapshots.attributesNotToStringify = undefined;
+
+      const wrapper = await mount(AttributesNotToStringify);
+
+      expect(wrapper)
+        .toMatchInlineSnapshot(`
+          <h1
+            class="active"
+            style="background: #F00; width: 0px;"
+            title="{ a: 2 }"
+          >
+            Text
+          </h1>
+        `);
+    });
+
+    test('Has no effect if stringifyAttributes is disabled', async () => {
+      globalThis.vueSnapshots.stringifyAttributes = false;
+      globalThis.vueSnapshots.attributesNotToStringify = ['style'];
+
+      const wrapper = await mount(AttributesNotToStringify);
+
+      expect(wrapper)
+        .toMatchInlineSnapshot(`
+          <h1
+            class="active"
+            style="background: #F00; width: 0px;"
+            title="[object Object]"
+          >
+            Text
+          </h1>
+        `);
+    });
+
+    test('Stringifies everything', async () => {
+      globalThis.vueSnapshots.stringifyAttributes = true;
+      globalThis.vueSnapshots.attributesNotToStringify = [];
+
+      const wrapper = await mount(AttributesNotToStringify);
+
+      expect(wrapper)
+        .toMatchInlineSnapshot(`
+          <h1
+            class="active"
+            style="{ background: '#F00', width: 0 }"
+            title="{ a: 2 }"
+          >
+            Text
+          </h1>
+        `);
+    });
+
+    test('Inverted settings', async () => {
+      globalThis.vueSnapshots.stringifyAttributes = true;
+      globalThis.vueSnapshots.attributesNotToStringify = ['title'];
+
+      const wrapper = await mount(AttributesNotToStringify);
+
+      expect(wrapper)
+        .toMatchInlineSnapshot(`
+          <h1
+            class="active"
+            style="{ background: '#F00', width: 0 }"
+            title="[object Object]"
+          >
+            Text
+          </h1>
+        `);
     });
   });
 

--- a/tests/unit/src/loadOptions.test.js
+++ b/tests/unit/src/loadOptions.test.js
@@ -15,6 +15,7 @@ describe('Load options', () => {
   const defaultSettings = Object.freeze({
     ...booleanDefaults,
     attributesToClear: [],
+    attributesNotToStringify: ['style'],
     stubs: {},
     formatter: 'diffable',
     formatting: {
@@ -40,7 +41,8 @@ describe('Load options', () => {
 
   test('Override defaults', () => {
     const invertedDefaults = {
-      attributesToClear: [false]
+      attributesToClear: [false],
+      attributesNotToStringify: []
     };
     for (const setting in booleanDefaults) {
       invertedDefaults[setting] = !booleanDefaults[setting];
@@ -52,7 +54,8 @@ describe('Load options', () => {
     expect(globalThis.vueSnapshots)
       .toEqual({
         ...invertedDefaults,
-        attributesToClear: []
+        attributesToClear: [],
+        attributesNotToStringify: []
       });
 
     expect(console.info)
@@ -66,6 +69,7 @@ describe('Load options', () => {
           settings: {
             addInputValues: false,
             attributesToClear: [],
+            attributesNotToStringify: [],
             clearInlineFunctions: true,
             debug: true,
             formatter: 'diffable',
@@ -107,6 +111,7 @@ describe('Load options', () => {
           settings: {
             addInputValues: false,
             attributesToClear: [],
+            attributesNotToStringify: [],
             clearInlineFunctions: true,
             debug: true,
             formatter: 'diffable',
@@ -203,6 +208,25 @@ describe('Load options', () => {
 
       expect(console.info)
         .toHaveBeenCalledWith('Vue 3 Snapshot Serializer: Attributes must be a type of string in global.vueSnapshots.attributesToClear. Received: 22');
+    });
+  });
+
+  describe('Attributes not to stringify', () => {
+    test('Sets attributesNotToStringify', () => {
+      globalThis.vueSnapshots = {
+        attributesNotToStringify: ['title', 'id', 'two words', 22]
+      };
+
+      loadOptions();
+
+      expect(globalThis.vueSnapshots.attributesNotToStringify)
+        .toEqual(['title', 'id']);
+
+      expect(console.info)
+        .toHaveBeenCalledWith('Vue 3 Snapshot Serializer: Attributes should not inlcude a space in global.vueSnapshots.attributesNotToStringify. Received: two words');
+
+      expect(console.info)
+        .toHaveBeenCalledWith('Vue 3 Snapshot Serializer: Attributes must be a type of string in global.vueSnapshots.attributesNotToStringify. Received: 22');
     });
   });
 

--- a/types.js
+++ b/types.js
@@ -76,7 +76,7 @@
  * @property {boolean}           [sortAttributes=true]                 Sorts the attributes inside HTML elements in the snapshot. This greatly reduces snapshot noise, making diffs easier to read.
  * @property {boolean}           [sortClasses=true]                    Sorts the classes inside the `class` attribute on all HTML elements in the snapshot. This greatly reduces snapshot noise, making diffs easier to read.
  * @property {boolean}           [stringifyAttributes=true]            Injects the real values of dynamic attributes/props into the snapshot. `to="[object Object]"` becomes `to="{ name: 'home' }"`. Requires passing in the VTU `wrapper` or TLV `wrapper`, not `wrapper.html()`.
- * @property {string[]}          [attributesNotToStringify=['style']]  If stringifyAttributes is enabled, the attributes defined here will be skipped, preserving the value set by Vue. Defaults to 'style', because Vue can accurately convert it to a string in the DOM without help.
+ * @property {string[]}          [attributesNotToStringify=['style']]  If stringifyAttributes is enabled, the attributes defined here will be skipped, preserving the value set by Vue. Defaults to 'style', because Vue can usually accurately convert it to a string in the DOM without help.
  * @property {boolean}           [removeServerRendered=true]           Removes `data-server-rendered="true"` from your snapshots if true.
  * @property {boolean}           [removeDataVId=true]                  Removes `data-v-1234abcd=""` from your snapshots if true. Useful if 3rd-party components use scoped styles to reduce snapshot noise when updating dependencies.
  * @property {boolean}           [removeDataTest=true]                 Removes `data-test="whatever"` from your snapshots if true.

--- a/types.js
+++ b/types.js
@@ -69,30 +69,31 @@
 
 /**
  * @typedef  {object}            SETTINGS
- * @property {boolean}           [verbose=true]                Logs to the console errors or other messages if true.
- * @property {boolean}           [debug=false]                 Logs to the console as internal functions are called, including relevant data to help in troubleshooting.
- * @property {string[]}          [attributesToClear=[]]        Takes an array of attribute strings, like `['title', 'id']`, to remove the values from these attributes. `<i title="9:04:55 AM" id="uuid_48a50d2" class="current-time"></i>` becomes `<i title id class="current-time"></i>`.
- * @property {boolean}           [addInputValues=true]         Display current internal element value on `input`, `textarea`, and `select` fields. `<input>` becomes `<input value="'whatever'">`. Requires passing in the VTU `wrapper` or TLV `wrapper`, not `wrapper.html()`.
- * @property {boolean}           [sortAttributes=true]         Sorts the attributes inside HTML elements in the snapshot. This greatly reduces snapshot noise, making diffs easier to read.
- * @property {boolean}           [sortClasses=true]            Sorts the classes inside the `class` attribute on all HTML elements in the snapshot. This greatly reduces snapshot noise, making diffs easier to read.
- * @property {boolean}           [stringifyAttributes=true]    Injects the real values of dynamic attributes/props into the snapshot. `to="[object Object]"` becomes `to="{ name: 'home' }"`. Requires passing in the VTU `wrapper` or TLV `wrapper`, not `wrapper.html()`.
- * @property {boolean}           [removeServerRendered=true]   Removes `data-server-rendered="true"` from your snapshots if true.
- * @property {boolean}           [removeDataVId=true]          Removes `data-v-1234abcd=""` from your snapshots if true. Useful if 3rd-party components use scoped styles to reduce snapshot noise when updating dependencies.
- * @property {boolean}           [removeDataTest=true]         Removes `data-test="whatever"` from your snapshots if true.
- * @property {boolean}           [removeDataTestid=true]       Removes `data-testid="whatever"` from your snapshots if true.
- * @property {boolean}           [removeDataTestId=true]       Removes `data-test-id="whatever"` from your snapshots if true.
- * @property {boolean}           [removeDataQa=false]          Removes `data-qa="whatever"` from your snapshots if true. `data-qa` is usually used by non-dev QA members. If they change in your snapshot, that indicates it may break someone else's E2E tests. So most using `data-qa` prefer they be left in by default.
- * @property {boolean}           [removeDataCy=false]          Removes `data-cy="whatever"` from your snapshots if true. `data-cy` is used by Cypress end-to-end tests. If they change in your snapshot, that indicates it may break an E2E test. So most using data-cy prefer they be left in by default.
- * @property {boolean}           [removeDataPw=false]          Removes `data-pw="whatever"` from your snapshots if true. `data-pw` is used by Playwright end-to-end tests. If they change in your snapshot, that indicates it may break an E2E test. So most using data-pw prefer they be left in by default.
- * @property {boolean}           [removeIdTest=false]          Removes `id="test-whatever"` or `id="testWhatever"` from snapshots. **Warning:** You should never use ID's for test tokens, as they can also be used by JS and CSS, making them more brittle and their intent less clear. Use `data-test-id` instead.
- * @property {boolean}           [removeClassTest=false]       Removes all CSS classes that start with "test", like `class="test-whatever"`. **Warning:** Don't use this approach. Use `data-test` instead. It is better suited for this because it doesn't conflate CSS and test tokens.
- * @property {boolean}           [removeComments=false]        Removes all HTML comments from your snapshots. This is false by default, as sometimes these comments can infer important information about how your DOM was rendered. However, this is mostly just personal preference.
- * @property {boolean}           [clearInlineFunctions=false]  Replaces `<div title="function () { return true; }"></div>` or `<div title="(x) => !x"></div>` with this placeholder `<div title="[function]"></div>`.
- * @property {STUBS}             [stubs={}]                    Allows targeting specific DOM nodes in the snapshot to optionally replace their tag name or remove attributes and innerHTML.
- * @property {POSTPROCESSOR}     [postProcessor]               This is a custom function you can pass in. It will be handed a string of formatted markup and must return a string (not a promise). It runs right after the formatter.
- * @property {FORMATTER}         [formatter='diffable']        Function to use for formatting the markup output. Accepts 'none', 'diffable', or 'classic'.
- * @property {FORMATTING}        [formatting]                  An object containing settings specific to the "diffable" formatter.
- * @property {CLASSICFORMATTING} [classicFormatting]           An object containing settings specific to the "classic" formatter.
+ * @property {boolean}           [verbose=true]                        Logs to the console errors or other messages if true.
+ * @property {boolean}           [debug=false]                         Logs to the console as internal functions are called, including relevant data to help in troubleshooting.
+ * @property {string[]}          [attributesToClear=[]]                Takes an array of attribute strings, like `['title', 'id']`, to remove the values from these attributes. `<i title="9:04:55 AM" id="uuid_48a50d2" class="current-time"></i>` becomes `<i title id class="current-time"></i>`.
+ * @property {boolean}           [addInputValues=true]                 Display current internal element value on `input`, `textarea`, and `select` fields. `<input>` becomes `<input value="'whatever'">`. Requires passing in the VTU `wrapper` or TLV `wrapper`, not `wrapper.html()`.
+ * @property {boolean}           [sortAttributes=true]                 Sorts the attributes inside HTML elements in the snapshot. This greatly reduces snapshot noise, making diffs easier to read.
+ * @property {boolean}           [sortClasses=true]                    Sorts the classes inside the `class` attribute on all HTML elements in the snapshot. This greatly reduces snapshot noise, making diffs easier to read.
+ * @property {boolean}           [stringifyAttributes=true]            Injects the real values of dynamic attributes/props into the snapshot. `to="[object Object]"` becomes `to="{ name: 'home' }"`. Requires passing in the VTU `wrapper` or TLV `wrapper`, not `wrapper.html()`.
+ * @property {string[]}          [attributesNotToStringify=['style']]  If stringifyAttributes is enabled, the attributes defined here will be skipped, preserving the value set by Vue. Defaults to 'style', because Vue can accurately convert it to a string in the DOM without help.
+ * @property {boolean}           [removeServerRendered=true]           Removes `data-server-rendered="true"` from your snapshots if true.
+ * @property {boolean}           [removeDataVId=true]                  Removes `data-v-1234abcd=""` from your snapshots if true. Useful if 3rd-party components use scoped styles to reduce snapshot noise when updating dependencies.
+ * @property {boolean}           [removeDataTest=true]                 Removes `data-test="whatever"` from your snapshots if true.
+ * @property {boolean}           [removeDataTestid=true]               Removes `data-testid="whatever"` from your snapshots if true.
+ * @property {boolean}           [removeDataTestId=true]               Removes `data-test-id="whatever"` from your snapshots if true.
+ * @property {boolean}           [removeDataQa=false]                  Removes `data-qa="whatever"` from your snapshots if true. `data-qa` is usually used by non-dev QA members. If they change in your snapshot, that indicates it may break someone else's E2E tests. So most using `data-qa` prefer they be left in by default.
+ * @property {boolean}           [removeDataCy=false]                  Removes `data-cy="whatever"` from your snapshots if true. `data-cy` is used by Cypress end-to-end tests. If they change in your snapshot, that indicates it may break an E2E test. So most using data-cy prefer they be left in by default.
+ * @property {boolean}           [removeDataPw=false]                  Removes `data-pw="whatever"` from your snapshots if true. `data-pw` is used by Playwright end-to-end tests. If they change in your snapshot, that indicates it may break an E2E test. So most using data-pw prefer they be left in by default.
+ * @property {boolean}           [removeIdTest=false]                  Removes `id="test-whatever"` or `id="testWhatever"` from snapshots. **Warning:** You should never use ID's for test tokens, as they can also be used by JS and CSS, making them more brittle and their intent less clear. Use `data-test-id` instead.
+ * @property {boolean}           [removeClassTest=false]               Removes all CSS classes that start with "test", like `class="test-whatever"`. **Warning:** Don't use this approach. Use `data-test` instead. It is better suited for this because it doesn't conflate CSS and test tokens.
+ * @property {boolean}           [removeComments=false]                Removes all HTML comments from your snapshots. This is false by default, as sometimes these comments can infer important information about how your DOM was rendered. However, this is mostly just personal preference.
+ * @property {boolean}           [clearInlineFunctions=false]          Replaces `<div title="function () { return true; }"></div>` or `<div title="(x) => !x"></div>` with this placeholder `<div title="[function]"></div>`.
+ * @property {STUBS}             [stubs={}]                            Allows targeting specific DOM nodes in the snapshot to optionally replace their tag name or remove attributes and innerHTML.
+ * @property {POSTPROCESSOR}     [postProcessor]                       This is a custom function you can pass in. It will be handed a string of formatted markup and must return a string (not a promise). It runs right after the formatter.
+ * @property {FORMATTER}         [formatter='diffable']                Function to use for formatting the markup output. Accepts 'none', 'diffable', or 'classic'.
+ * @property {FORMATTING}        [formatting]                          An object containing settings specific to the "diffable" formatter.
+ * @property {CLASSICFORMATTING} [classicFormatting]                   An object containing settings specific to the "classic" formatter.
  */
 
 /** @typedef {'root'|'tag'|'text'|'comment'|'doctype'|'cdata'|'script'|'style'|'directive'} ASTNODETYPE */


### PR DESCRIPTION
Closes #107 


**Notes for reviewer:**

* Turns out `class` is already converted to a normal string in the virtual DOM by the time we get to it, so we only need to worry about `style` being weird.


<!-- If you don't know what this is, ignore it -->
**Checklist:**

* [x] Update documentation site
* [x] Update dependencies
* [x] Run `volta pin node@latest && volta pin npm@latest` 
* [x] Bump
* [x] If API changed, update `types.js`
